### PR TITLE
fix: handle rpm-ostree distros and mark as systemd-enabled

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -20,6 +20,9 @@ import (
 )
 
 func isSystemd() bool {
+	if _, err := exec.LookPath("rpm-ostree"); err == nil {
+		return true
+	}
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		return true
 	}


### PR DESCRIPTION
On rpm-ostree fueled distro, the first check for `/run/systemd/` existence will always be skipped in a postinstall environment. In that isolated environment `/run/systemd` is simply not present. We can rely on binaries for sure.

Assuming all rpm-ostree distros are systemd enabled by default fixes the issue.

NOTE:
Out of postinstall environment (the standalone binary executed as root), systemd is correctly detected (also in 0.29.0)